### PR TITLE
chore: [SNOW-3097634] set @snowflakedb/snowcli as global codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sfc-gh-moczko @sfc-gh-turbaszek @sfc-gh-astus @sfc-gh-pczajka @sfc-gh-mraba @sfc-gh-jsikorski @sfc-gh-mtrzaskowski @sfc-gh-jwilkowski @sfc-gh-sandrian
+* @snowflakedb/snowcli


### PR DESCRIPTION
## Description
Updates the `CODEOWNERS` file to set `@snowflakedb/snowcli` as the default owner for all files (`*`).