### PR TITLE
feat: [SNOW-3167708] add OIDC workload identity support via service connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,49 +21,67 @@ Path to the configuration file (`config.toml`) in your repository. The path must
 
 ### `use-workload-identity`
 
-Boolean flag to enable Azure workload identity authentication. When set to `true`, the task will configure the CLI to use the Azure managed identity of the pipeline agent for authentication with Snowflake, eliminating the need for storing credentials as secrets. Default is `false`.
+Boolean flag to enable OIDC workload identity authentication. When set to `true`, the task will request an OIDC token from Azure DevOps using the specified service connection and configure the Snowflake driver to authenticate via workload identity federation, eliminating the need for storing credentials as secrets. Requires `connected-service-name`. Default is `false`.
+
+### `connected-service-name`
+
+The name of an Azure Resource Manager service connection configured with workload identity federation. Required when `use-workload-identity` is `true`. The task uses this service connection to request an OIDC token from Azure DevOps.
 
 ## How to Safely Configure the Pipeline
 
-### Use Azure workload identity authentication
+### Use workload identity authentication (OIDC)
 
-Azure workload identity authentication provides a secure and modern way to authenticate with Snowflake without storing credentials as secrets. This approach uses the Azure managed identity attached to the pipeline agent to authenticate with Snowflake.
+Workload identity federation provides a secure way to authenticate with Snowflake from Azure DevOps pipelines without storing credentials as secrets. The task requests an OIDC token from Azure DevOps via the service connection and passes it to the Snowflake driver.
 
-To set up Azure workload identity authentication, follow these steps:
+To set up workload identity authentication, follow these steps:
 
-1. **Configure Microsoft Entra ID**:
+1. **Create an Azure App Registration with a federated credential**:
 
-   A Microsoft Entra ID tenant administrator must consent to the multi-tenant Snowflake EntraID app by visiting the [consent URI](https://login.microsoftonline.com/common/adminconsent?client_id=2b0bfd60-5ae4-4edb-aaad-0feb7e2fac24). This only needs to be done once per tenant.
+   Create an App Registration in Microsoft Entra ID and add a federated credential for your ADO service connection. See the [Azure documentation](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust) for details.
 
-2. **Enable a managed identity on the pipeline agent**:
+2. **Create an Azure DevOps service connection**:
 
-   Enable a managed identity for the Azure VM or Azure Function that runs your pipeline agent. Save the Object (Principal) ID for the next step. See the [Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) for details.
+   In your ADO project, create an Azure Resource Manager service connection using Workload Identity Federation. Note the service connection name for the pipeline configuration.
 
 3. **Configure Snowflake**:
 
-   Create a service user with Azure workload identity type:
+   Create a service user with OIDC workload identity. The `ISSUER` and `SUBJECT` values come from the OIDC token issued by the service connection. To discover these values, add a debug step to your pipeline:
+
+   ```yaml
+   - bash: |
+       cat "$SNOWFLAKE_TOKEN_FILE_PATH" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | python3 -m json.tool
+     displayName: 'Debug: inspect OIDC token claims'
+   ```
+
+   Then create (or alter) the Snowflake user:
 
    ```sql
    CREATE USER <username>
      WORKLOAD_IDENTITY = (
-       TYPE = AZURE
-       ISSUER = 'https://login.microsoftonline.com/<tenant_id>/v2.0'
-       SUBJECT = '<object_principal_id>'
+       TYPE = OIDC
+       ISSUER = '<iss claim from token>'
+       SUBJECT = '<sub claim from token>'
+       OIDC_AUDIENCE_LIST = ('<aud claim from token>')
      )
      TYPE = SERVICE
      DEFAULT_ROLE = PUBLIC;
    ```
 
-   - `<tenant_id>` is your Microsoft Entra tenant ID
-   - `<object_principal_id>` is the Object (Principal) ID of the managed identity
-
    For more details, see the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/workload-identity-federation).
 
-4. **Store your Snowflake account in Azure DevOps Pipeline Secrets**:
+4. **Configure the pipeline**:
 
-   Store your Snowflake account identifier in Azure DevOps Pipeline Secrets. Refer to the [Azure DevOps documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-secret-variables?view=azure-devops&tabs=yaml%2Cbash#secret-variable-in-the-ui) for detailed instructions.
+   Add a `config.toml` to your repository (no credentials needed):
 
-5. **Configure the Snowflake CLI Task with workload identity authentication**:
+   ```toml
+   [connections.default]
+   account = "<your_account>"
+   user = "<snowflake_service_user>"
+   warehouse = "COMPUTE_WH"
+   role = "SYSADMIN"
+   ```
+
+   Then configure your pipeline YAML:
 
    ```yaml
    trigger:
@@ -78,14 +96,12 @@ To set up Azure workload identity authentication, follow these steps:
        configFilePath: './config.toml'
        cliVersion: 'latest'
        useWorkloadIdentity: true
-     displayName: Configure Snowflake CLI with Azure Workload Identity
+       connectedServiceName: '<your-service-connection-name>'
+     displayName: Configure Snowflake CLI with Workload Identity
 
    - script: |
        snow --version
-       snow connection test -x
-     env:
-       SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)
-       SNOWFLAKE_USER: $(SNOWFLAKE_USER)
+       snow connection test
    ```
 
 ### Alternative authentication methods

--- a/README.md
+++ b/README.md
@@ -19,7 +19,80 @@ The specified Snowflake CLI version. For example, `2.2.0`. If not specified, the
 
 Path to the configuration file (`config.toml`) in your repository. The path must be relative to the root of your repository.
 
+### `use-workload-identity`
+
+Boolean flag to enable Azure workload identity authentication. When set to `true`, the task will configure the CLI to use the Azure managed identity of the pipeline agent for authentication with Snowflake, eliminating the need for storing credentials as secrets. Default is `false`.
+
 ## How to Safely Configure the Pipeline
+
+### Use Azure workload identity authentication
+
+Azure workload identity authentication provides a secure and modern way to authenticate with Snowflake without storing credentials as secrets. This approach uses the Azure managed identity attached to the pipeline agent to authenticate with Snowflake.
+
+To set up Azure workload identity authentication, follow these steps:
+
+1. **Configure Microsoft Entra ID**:
+
+   A Microsoft Entra ID tenant administrator must consent to the multi-tenant Snowflake EntraID app by visiting the [consent URI](https://login.microsoftonline.com/common/adminconsent?client_id=2b0bfd60-5ae4-4edb-aaad-0feb7e2fac24). This only needs to be done once per tenant.
+
+2. **Enable a managed identity on the pipeline agent**:
+
+   Enable a managed identity for the Azure VM or Azure Function that runs your pipeline agent. Save the Object (Principal) ID for the next step. See the [Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) for details.
+
+3. **Configure Snowflake**:
+
+   Create a service user with Azure workload identity type:
+
+   ```sql
+   CREATE USER <username>
+     WORKLOAD_IDENTITY = (
+       TYPE = AZURE
+       ISSUER = 'https://login.microsoftonline.com/<tenant_id>/v2.0'
+       SUBJECT = '<object_principal_id>'
+     )
+     TYPE = SERVICE
+     DEFAULT_ROLE = PUBLIC;
+   ```
+
+   - `<tenant_id>` is your Microsoft Entra tenant ID
+   - `<object_principal_id>` is the Object (Principal) ID of the managed identity
+
+   For more details, see the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/workload-identity-federation).
+
+4. **Store your Snowflake account in Azure DevOps Pipeline Secrets**:
+
+   Store your Snowflake account identifier in Azure DevOps Pipeline Secrets. Refer to the [Azure DevOps documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-secret-variables?view=azure-devops&tabs=yaml%2Cbash#secret-variable-in-the-ui) for detailed instructions.
+
+5. **Configure the Snowflake CLI Task with workload identity authentication**:
+
+   ```yaml
+   trigger:
+   - main
+
+   pool:
+     vmImage: ubuntu-latest
+
+   steps:
+   - task: ConfigureSnowflakeCLI@0
+     inputs:
+       configFilePath: './config.toml'
+       cliVersion: 'latest'
+       useWorkloadIdentity: true
+     displayName: Configure Snowflake CLI with Azure Workload Identity
+
+   - script: |
+       snow --version
+       snow connection test -x
+     env:
+       SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)
+       SNOWFLAKE_USER: $(SNOWFLAKE_USER)
+   ```
+
+### Alternative authentication methods
+
+The following methods can be used as alternatives to workload identity authentication:
+
+#### Key-Pair Authentication
 
 To set up Snowflake credentials for a specific connection, follow these steps:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Path to the configuration file (`config.toml`) in your repository. The path must
 
 ### `use-workload-identity`
 
-Boolean flag to enable OIDC workload identity authentication. When set to `true`, the task will request an OIDC token from Azure DevOps using the specified service connection and configure the Snowflake driver to authenticate via workload identity federation, eliminating the need for storing credentials as secrets. Requires `connected-service-name`. Default is `false`.
+Boolean flag to enable workload identity federation authentication. When set to `true`, the task will request an OIDC token from Azure DevOps using the specified service connection and configure the Snowflake driver to authenticate with obtained token, eliminating the need for storing credentials as secrets. Requires `connected-service-name`. Default is `false`.
 
 ### `connected-service-name`
 
@@ -45,29 +45,35 @@ To set up workload identity authentication, follow these steps:
 
 3. **Configure Snowflake**:
 
-   Create a service user with OIDC workload identity. The `ISSUER` and `SUBJECT` values come from the OIDC token issued by the service connection. To discover these values, add a debug step to your pipeline:
+   Create a service user with OIDC workload identity. The claim values for Azure DevOps OIDC tokens follow predictable patterns:
 
-   ```yaml
-   - bash: |
-       cat "$SNOWFLAKE_TOKEN_FILE_PATH" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | python3 -m json.tool
-     displayName: 'Debug: inspect OIDC token claims'
-   ```
+   - **Issuer** (`iss`): `https://vstoken.dev.azure.com/<Azure-AD-Tenant-ID>`
+   - **Subject** (`sub`): `sc://<ADO-Org-Name>/<ADO-Project-Name>/<Service-Connection-Name>`
+   - **Audience** (`aud`): `api://AzureADTokenExchange`
 
-   Then create (or alter) the Snowflake user:
+   Use these values to create (or alter) the Snowflake user:
 
    ```sql
    CREATE USER <username>
      WORKLOAD_IDENTITY = (
        TYPE = OIDC
-       ISSUER = '<iss claim from token>'
-       SUBJECT = '<sub claim from token>'
-       OIDC_AUDIENCE_LIST = ('<aud claim from token>')
+       ISSUER = 'https://vstoken.dev.azure.com/<Azure-AD-Tenant-ID>'
+       SUBJECT = 'sc://<ADO-Org-Name>/<ADO-Project-Name>/<Service-Connection-Name>'
+       OIDC_AUDIENCE_LIST = ('api://AzureADTokenExchange')
      )
      TYPE = SERVICE
      DEFAULT_ROLE = PUBLIC;
    ```
 
    For more details, see the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/workload-identity-federation).
+
+   > **Troubleshooting**: If authentication fails due to a claim mismatch, you can inspect the actual token claims by adding a debug step to your pipeline:
+   >
+   > ```yaml
+   > - bash: |
+   >     echo "$SNOWFLAKE_TOKEN" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | python3 -m json.tool
+   >   displayName: 'Debug: inspect OIDC token claims'
+   > ```
 
 4. **Configure the pipeline**:
 
@@ -76,9 +82,8 @@ To set up workload identity authentication, follow these steps:
    ```toml
    [connections.default]
    account = "<your_account>"
-   user = "<snowflake_service_user>"
    warehouse = "COMPUTE_WH"
-   role = "SYSADMIN"
+   role = "PUBLIC"
    ```
 
    Then configure your pipeline YAML:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,11 +11,12 @@ schedules:
 pool:
   vmImage: ubuntu-latest
 
+steps:
 - script: |
     cat <<EOF > config.toml
-    default_connection_name = "myconnection" 
-      
-    [connections] 
+    default_connection_name = "myconnection"
+
+    [connections]
     [connections.myconnection]
     user = "demo_user"
     warehouse = "COMPUTE_WH"
@@ -24,14 +25,14 @@ pool:
     role = "ACCOUNTADMIN"
     region = "us-east-1"
     EOF
-  displayName: 'Create Sample File with Multiple Lines'
+  displayName: 'Create Sample config.toml'
 
-steps:
 - task: ConfigureSnowflakeCLI@0
   inputs:
     configFilePath: './config.toml'
     cliVersion: '2.3.0'
+
   displayName: SnowflakeCliTest
 
-- script: snow connection list 
-  displayName: 'Snow Version'
+- script: snow connection list
+  displayName: 'Snow Connection List'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
 - task: ConfigureSnowflakeCLI@0
   inputs:
     configFilePath: './config.toml'
-    cliVersion: '2.3.0'
+    cliVersion: '3.15.0'
 
   displayName: SnowflakeCliTest
 

--- a/tasks/configure_snowflake_cli/main.ts
+++ b/tasks/configure_snowflake_cli/main.ts
@@ -26,10 +26,14 @@ async function run() {
         const configFilePath: string | undefined = tl.getInput('configFilePath', false);
         const cliVersion: string | undefined = tl.getInput('cliVersion', false);
         const useWorkloadIdentity: boolean = tl.getBoolInput('useWorkloadIdentity', false);
+        const connectedServiceName: string | undefined = tl.getInput('connectedServiceName', false);
         installSnowflakeCli(cliVersion);
         setupConfigFile(configFilePath);
         if (useWorkloadIdentity) {
-            await setupWorkloadIdentity();
+            if (!connectedServiceName) {
+                throw new Error('connectedServiceName is required when useWorkloadIdentity is true.');
+            }
+            await setupWorkloadIdentity(connectedServiceName);
         }
     }
     catch (err:any) {

--- a/tasks/configure_snowflake_cli/main.ts
+++ b/tasks/configure_snowflake_cli/main.ts
@@ -18,14 +18,19 @@ import path from 'path';
 import * as task from 'azure-pipelines-task-lib';
 import { setupConfigFile } from './src/setupConfigFile';
 import { installSnowflakeCli } from './src/installSnowflakeCli';
+import { setupWorkloadIdentity } from './src/setupWorkloadIdentity';
 
 async function run() {
     try {
         task.setResourcePath(path.join(__dirname, 'task.json'));
         const configFilePath: string | undefined = tl.getInput('configFilePath', false);
         const cliVersion: string | undefined = tl.getInput('cliVersion', false);
+        const useWorkloadIdentity: boolean = tl.getBoolInput('useWorkloadIdentity', false);
         installSnowflakeCli(cliVersion);
         setupConfigFile(configFilePath);
+        if (useWorkloadIdentity) {
+            await setupWorkloadIdentity();
+        }
     }
     catch (err:any) {
         tl.setResult(tl.TaskResult.Failed, err.message);

--- a/tasks/configure_snowflake_cli/main.ts
+++ b/tasks/configure_snowflake_cli/main.ts
@@ -27,13 +27,13 @@ async function run() {
         const cliVersion: string | undefined = tl.getInput('cliVersion', false);
         const useWorkloadIdentity: boolean = tl.getBoolInput('useWorkloadIdentity', false);
         const connectedServiceName: string | undefined = tl.getInput('connectedServiceName', false);
+        if (useWorkloadIdentity && !connectedServiceName) {
+            throw new Error('connectedServiceName is required when useWorkloadIdentity is true.');
+        }
         installSnowflakeCli(cliVersion);
         setupConfigFile(configFilePath);
         if (useWorkloadIdentity) {
-            if (!connectedServiceName) {
-                throw new Error('connectedServiceName is required when useWorkloadIdentity is true.');
-            }
-            await setupWorkloadIdentity(connectedServiceName);
+            await setupWorkloadIdentity(connectedServiceName!);
         }
     }
     catch (err:any) {

--- a/tasks/configure_snowflake_cli/package-lock.json
+++ b/tasks/configure_snowflake_cli/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/node": "^20.14.2",
         "@types/q": "^1.5.8",
+        "azure-devops-node-api": "^14.1.0",
         "azure-pipelines-task-lib": "^4.13.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "sync-request": "^6.1.0",
@@ -151,6 +152,35 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
+      "integrity": "sha512-QhpgjH1LQ+vgDJ7oBwcmsZ3+o4ZpjLVilw0D3oJQpYpRzN+L39lk5jZDLJ464hLUgsDzWn/Ksv7zLLMKLfoBzA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "2.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha512-Nel9aPbgSzRxfs1+4GoSB4wexCF+4Axlk7OSGVQCMa+4fWcyxIsN/YNmkp0xTT2iQzMD98h8yFLav/cNaULmRA==",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-task-lib": {
       "version": "4.13.0",
@@ -430,6 +460,16 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -873,6 +913,12 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -934,6 +980,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/tasks/configure_snowflake_cli/package.json
+++ b/tasks/configure_snowflake_cli/package.json
@@ -15,6 +15,7 @@
   "author": "Snowflake Labs",
   "license": "Apache License 2.0",
   "dependencies": {
+    "azure-devops-node-api": "^14.1.0",
     "azure-pipelines-task-lib": "^4.13.0",
     "azure-pipelines-tool-lib": "^2.0.7",
     "@types/node": "^20.14.2",

--- a/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
+++ b/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
@@ -15,9 +15,6 @@
 
 import tl = require('azure-pipelines-task-lib');
 import * as azdev from 'azure-devops-node-api';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
 
 export async function setupWorkloadIdentity(connectedServiceName: string) {
     const jobId = tl.getVariable('System.JobId');
@@ -59,19 +56,10 @@ export async function setupWorkloadIdentity(connectedServiceName: string) {
 
     console.log('OIDC token obtained successfully.');
 
-    // Write the token to a temp file for the Snowflake connector to read
-    const tokenDir = path.join(os.tmpdir(), 'snowflake-wif');
-    if (!fs.existsSync(tokenDir)) {
-        fs.mkdirSync(tokenDir, { recursive: true });
-    }
-    const tokenFilePath = path.join(tokenDir, 'oidc_token');
-    fs.writeFileSync(tokenFilePath, oidcToken, { mode: 0o600 });
-
     // Set environment variables for the Snowflake CLI / connector
     tl.setVariable('SNOWFLAKE_AUTHENTICATOR', 'WORKLOAD_IDENTITY');
     tl.setVariable('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER', 'OIDC');
-    tl.setVariable('SNOWFLAKE_TOKEN_FILE_PATH', tokenFilePath);
+    tl.setVariable('SNOWFLAKE_TOKEN', oidcToken, true);
 
     console.log('Workload identity authentication configured successfully (OIDC).');
-    console.log(`Token file written to: ${tokenFilePath}`);
 }

--- a/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
+++ b/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 Snowflake Inc. 
+// Copyright 2026 Snowflake Inc.
 // SPDX-License-Identifier: Apache-2.0
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
+++ b/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
@@ -1,0 +1,27 @@
+// Copyright 2024 Snowflake Inc. 
+// SPDX-License-Identifier: Apache-2.0
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import tl = require('azure-pipelines-task-lib');
+
+export async function setupWorkloadIdentity() {
+    try {
+        tl.setVariable('SNOWFLAKE_AUTHENTICATOR', 'WORKLOAD_IDENTITY');
+        tl.setVariable('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER', 'AZURE');
+
+        console.log('Azure workload identity authentication configured successfully.');
+    } catch (err: any) {
+        tl.setResult(tl.TaskResult.Failed, err.message);
+    }
+}

--- a/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
+++ b/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
@@ -21,7 +21,7 @@ function getRequiredVariable(name: string): string {
     if (!value) {
         throw new Error(
             `Missing required pipeline variable '${name}'. ` +
-            'Ensure System.AccessToken is available (add "- checkout: self" or set env explicitly).'
+            `Ensure '${name}' is available (add "- checkout: self" or set env explicitly).`
         );
     }
     return value;

--- a/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
+++ b/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
@@ -14,14 +14,64 @@
 // limitations under the License.
 
 import tl = require('azure-pipelines-task-lib');
+import * as azdev from 'azure-devops-node-api';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
-export async function setupWorkloadIdentity() {
-    try {
-        tl.setVariable('SNOWFLAKE_AUTHENTICATOR', 'WORKLOAD_IDENTITY');
-        tl.setVariable('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER', 'AZURE');
+export async function setupWorkloadIdentity(connectedServiceName: string) {
+    const jobId = tl.getVariable('System.JobId');
+    const planId = tl.getVariable('System.PlanId');
+    const projectId = tl.getVariable('System.TeamProjectId');
+    const hub = tl.getVariable('System.HostType');
+    const collectionUri = tl.getVariable('System.CollectionUri');
+    const accessToken = tl.getVariable('System.AccessToken');
 
-        console.log('Azure workload identity authentication configured successfully.');
-    } catch (err: any) {
-        tl.setResult(tl.TaskResult.Failed, err.message);
+    if (!jobId || !planId || !projectId || !hub || !collectionUri || !accessToken) {
+        throw new Error(
+            'Missing required pipeline variables. Ensure System.AccessToken is available ' +
+            '(add "- checkout: self" or set env explicitly).'
+        );
     }
+
+    console.log('Requesting OIDC token from Azure DevOps...');
+
+    const authHandler = azdev.getPersonalAccessTokenHandler(accessToken);
+    const connection = new azdev.WebApi(collectionUri, authHandler);
+    const taskApi = await connection.getTaskApi();
+
+    const response = await taskApi.createOidcToken(
+        {},
+        projectId,
+        hub,
+        planId,
+        jobId,
+        connectedServiceName
+    );
+
+    const oidcToken = response?.oidcToken;
+    if (!oidcToken) {
+        throw new Error(
+            'Failed to obtain OIDC token from Azure DevOps. ' +
+            'Verify the service connection is configured with workload identity federation.'
+        );
+    }
+
+    console.log('OIDC token obtained successfully.');
+
+    // Write the token to a temp file for the Snowflake connector to read
+    const tokenDir = path.join(os.tmpdir(), 'snowflake-wif');
+    if (!fs.existsSync(tokenDir)) {
+        fs.mkdirSync(tokenDir, { recursive: true });
+    }
+    const tokenFilePath = path.join(tokenDir, 'oidc_token');
+    fs.writeFileSync(tokenFilePath, oidcToken, { mode: 0o600 });
+
+    // Set environment variables for the Snowflake CLI / connector
+    tl.setVariable('SNOWFLAKE_AUTHENTICATOR', 'WORKLOAD_IDENTITY');
+    tl.setVariable('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER', 'OIDC');
+    tl.setVariable('SNOWFLAKE_TOKEN_FILE_PATH', tokenFilePath);
+
+    console.log('Workload identity authentication configured successfully (OIDC).');
+    console.log(`Token file written to: ${tokenFilePath}`);
 }

--- a/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
+++ b/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
@@ -16,20 +16,24 @@
 import tl = require('azure-pipelines-task-lib');
 import * as azdev from 'azure-devops-node-api';
 
-export async function setupWorkloadIdentity(connectedServiceName: string) {
-    const jobId = tl.getVariable('System.JobId');
-    const planId = tl.getVariable('System.PlanId');
-    const projectId = tl.getVariable('System.TeamProjectId');
-    const hub = tl.getVariable('System.HostType');
-    const collectionUri = tl.getVariable('System.CollectionUri');
-    const accessToken = tl.getVariable('System.AccessToken');
-
-    if (!jobId || !planId || !projectId || !hub || !collectionUri || !accessToken) {
+function getRequiredVariable(name: string): string {
+    const value = tl.getVariable(name);
+    if (!value) {
         throw new Error(
-            'Missing required pipeline variables. Ensure System.AccessToken is available ' +
-            '(add "- checkout: self" or set env explicitly).'
+            `Missing required pipeline variable '${name}'. ` +
+            'Ensure System.AccessToken is available (add "- checkout: self" or set env explicitly).'
         );
     }
+    return value;
+}
+
+export async function setupWorkloadIdentity(connectedServiceName: string) {
+    const jobId = getRequiredVariable('System.JobId');
+    const planId = getRequiredVariable('System.PlanId');
+    const projectId = getRequiredVariable('System.TeamProjectId');
+    const hub = getRequiredVariable('System.HostType');
+    const collectionUri = getRequiredVariable('System.CollectionUri');
+    const accessToken = getRequiredVariable('System.AccessToken');
 
     console.log('Requesting OIDC token from Azure DevOps...');
 

--- a/tasks/configure_snowflake_cli/task.json
+++ b/tasks/configure_snowflake_cli/task.json
@@ -33,10 +33,19 @@
         {
             "name": "useWorkloadIdentity",
             "type": "boolean",
-            "label": "Enable Azure workload identity authentication",
+            "label": "Enable workload identity authentication",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "Enable Azure workload identity authentication for Snowflake CLI. When set to true, the task will set SNOWFLAKE_AUTHENTICATOR and SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER environment variables so that the Snowflake driver authenticates using the Azure managed identity of the pipeline agent."
+            "helpMarkDown": "Enable OIDC workload identity authentication for Snowflake CLI. When set to true, the task will request an OIDC token from Azure DevOps using the specified service connection and configure the Snowflake driver to authenticate via workload identity federation."
+        },
+        {
+            "name": "connectedServiceName",
+            "type": "connectedService:AzureRM",
+            "label": "Azure Service Connection",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "The Azure Resource Manager service connection configured with workload identity federation. Required when useWorkloadIdentity is true.",
+            "visibleRule": "useWorkloadIdentity = true"
         }
     ],
     "execution": {

--- a/tasks/configure_snowflake_cli/task.json
+++ b/tasks/configure_snowflake_cli/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "instanceNameFormat": "Configure Snowflake CLI",
     "inputs": [
@@ -29,6 +29,14 @@
             "defaultValue": "latest",
             "required": true,
             "helpMarkDown": "The Snowflake CLI version to be installed."
+        },
+        {
+            "name": "useWorkloadIdentity",
+            "type": "boolean",
+            "label": "Enable Azure workload identity authentication",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Enable Azure workload identity authentication for Snowflake CLI. When set to true, the task will set SNOWFLAKE_AUTHENTICATOR and SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER environment variables so that the Snowflake driver authenticates using the Azure managed identity of the pipeline agent."
         }
     ],
     "execution": {

--- a/tasks/configure_snowflake_cli/task.json
+++ b/tasks/configure_snowflake_cli/task.json
@@ -36,7 +36,7 @@
             "label": "Enable workload identity authentication",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "Enable OIDC workload identity authentication for Snowflake CLI. When set to true, the task will request an OIDC token from Azure DevOps using the specified service connection and configure the Snowflake driver to authenticate via workload identity federation."
+            "helpMarkDown": "Enable workload identity authentication for Snowflake CLI. When set to true, the task will request an OIDC token from Azure DevOps using the specified service connection and configure the Snowflake driver to authenticate with obtained token."
         },
         {
             "name": "connectedServiceName",

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
@@ -82,6 +82,31 @@ describe('Snowflake Cli configuration', function () {
         });
     });
 
+    it('it should succeed with workload identity when connectedServiceName is provided', function(done: Mocha.Done) {
+        this.timeout(10000);    
+        const tp: string = path.join(__dirname, 'workloadIdentitySuccessWithTokenSample.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    
+        tr.runAsync().then(async () => {
+            const test = require ('node:test');
+
+            assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+            await test('Should set SNOWFLAKE_AUTHENTICATOR', () => {
+                assert.equal(tr.stdout.indexOf('SNOWFLAKE_AUTHENTICATOR') >= 0, true, "should set SNOWFLAKE_AUTHENTICATOR");
+            })
+
+            await test('Should log success message', () => {
+                assert.equal(tr.stdout.indexOf('Workload identity authentication configured successfully') >= 0, true, "should log success");
+            })
+
+            done();
+        }).catch((error) => {
+            done(error);
+        });
+    });
+
     it('it should fail when useWorkloadIdentity is true but connectedServiceName is missing', function(done: Mocha.Done) {
         this.timeout(10000);    
         const tp: string = path.join(__dirname, 'workloadIdentitySuccessSample.js');

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
@@ -82,7 +82,7 @@ describe('Snowflake Cli configuration', function () {
         });
     });
 
-    it('it should configure workload identity authentication variables', function(done: Mocha.Done) {
+    it('it should fail when useWorkloadIdentity is true but connectedServiceName is missing', function(done: Mocha.Done) {
         this.timeout(10000);    
         const tp: string = path.join(__dirname, 'workloadIdentitySuccessSample.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -90,12 +90,10 @@ describe('Snowflake Cli configuration', function () {
         tr.runAsync().then(async () => {
             const test = require ('node:test');
 
-            await test('Should set SNOWFLAKE_AUTHENTICATOR variable', () => {
-                assert.equal(tr.stdout.indexOf('SNOWFLAKE_AUTHENTICATOR=WORKLOAD_IDENTITY') >= 0, true, "should set SNOWFLAKE_AUTHENTICATOR");
-            })
+            assert.equal(tr.succeeded, false, 'should have failed');
 
-            await test('Should set SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER variable', () => {
-                assert.equal(tr.stdout.indexOf('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER=AZURE') >= 0, true, "should set SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER");
+            await test('Should fail with missing connectedServiceName error', () => {
+                assert.equal(tr.errorIssues.some((e: string) => e.indexOf('connectedServiceName is required') >= 0), true, "should report missing connectedServiceName");
             })
 
             done();

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
@@ -82,6 +82,28 @@ describe('Snowflake Cli configuration', function () {
         });
     });
 
+    it('it should configure workload identity authentication variables', function(done: Mocha.Done) {
+        this.timeout(10000);    
+        const tp: string = path.join(__dirname, 'workloadIdentitySuccessSample.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    
+        tr.runAsync().then(async () => {
+            const test = require ('node:test');
+
+            await test('Should set SNOWFLAKE_AUTHENTICATOR variable', () => {
+                assert.equal(tr.stdout.indexOf('SNOWFLAKE_AUTHENTICATOR=WORKLOAD_IDENTITY') >= 0, true, "should set SNOWFLAKE_AUTHENTICATOR");
+            })
+
+            await test('Should set SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER variable', () => {
+                assert.equal(tr.stdout.indexOf('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER=AZURE') >= 0, true, "should set SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER");
+            })
+
+            done();
+        }).catch((error) => {
+            done(error);
+        });
+    });
+
     it('it should fail if PIPX_BIN_DIR is not set', function(done: Mocha.Done) {
         this.timeout(10000);    
         const tp: string = path.join(__dirname, 'PipxBinDirNotSetSample.js');

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
@@ -83,18 +83,27 @@ describe('Snowflake Cli configuration', function () {
     });
 
     it('it should succeed with workload identity when connectedServiceName is provided', function(done: Mocha.Done) {
-        this.timeout(10000);    
+        this.timeout(10000);
         const tp: string = path.join(__dirname, 'workloadIdentitySuccessWithTokenSample.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-    
+
         tr.runAsync().then(async () => {
             const test = require ('node:test');
 
             assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.warningIssues.length, 0, "should have no warnings");
             assert.equal(tr.errorIssues.length, 0, "should have no errors");
 
-            await test('Should set SNOWFLAKE_AUTHENTICATOR', () => {
-                assert.equal(tr.stdout.indexOf('SNOWFLAKE_AUTHENTICATOR') >= 0, true, "should set SNOWFLAKE_AUTHENTICATOR");
+            await test('Should set SNOWFLAKE_AUTHENTICATOR to WORKLOAD_IDENTITY', () => {
+                assert.equal(tr.stdout.indexOf('SNOWFLAKE_AUTHENTICATOR=WORKLOAD_IDENTITY') >= 0, true, "should set SNOWFLAKE_AUTHENTICATOR");
+            })
+
+            await test('Should set SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER to OIDC', () => {
+                assert.equal(tr.stdout.indexOf('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER=OIDC') >= 0, true, "should set SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER");
+            })
+
+            await test('Should set SNOWFLAKE_TOKEN as secret', () => {
+                assert.equal(tr.stdout.indexOf('SNOWFLAKE_TOKEN=') >= 0, true, "should set SNOWFLAKE_TOKEN");
             })
 
             await test('Should log success message', () => {
@@ -114,12 +123,28 @@ describe('Snowflake Cli configuration', function () {
     
         tr.runAsync().then(async () => {
             const test = require ('node:test');
+            assert.equal(tr.succeeded, false, 'should have not succeeded');
+            assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+            assert.equal(tr.errorIssues.length, 1, "should have one error");
+            assert.match(tr.errorIssues[0], new RegExp('connectedServiceName is required'), 'should report missing connectedServiceName');
 
-            assert.equal(tr.succeeded, false, 'should have failed');
+            done();
+        }).catch((error) => {
+            done(error);
+        });
+    });
 
-            await test('Should fail with missing connectedServiceName error', () => {
-                assert.equal(tr.errorIssues.some((e: string) => e.indexOf('connectedServiceName is required') >= 0), true, "should report missing connectedServiceName");
-            })
+    it('it should fail when a required pipeline variable is missing', function(done: Mocha.Done) {
+        this.timeout(10000);
+        const tp: string = path.join(__dirname, 'workloadIdentityMissingVariableSample.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.runAsync().then(async () => {
+            const test = require ('node:test');
+            assert.equal(tr.succeeded, false, 'should have not succeeded');
+            assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+            assert.equal(tr.errorIssues.length, 1, "should have one error");
+            assert.match(tr.errorIssues[0], new RegExp("Missing required pipeline variable 'System.AccessToken'"), 'should report missing System.AccessToken');
 
             done();
         }).catch((error) => {

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentityMissingVariableSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentityMissingVariableSample.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Snowflake Inc.
+// SPDX-License-Identifier: Apache-2.0
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path from 'path';
+import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
+
+const taskPath = path.join(__dirname, '..', '..', 'main.js');
+
+const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
+process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
+process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+
+// Set some pipeline variables but deliberately omit System.AccessToken
+process.env["SYSTEM_JOBID"] = 'fake-job-id';
+process.env["SYSTEM_PLANID"] = 'fake-plan-id';
+process.env["SYSTEM_TEAMPROJECTID"] = 'fake-project-id';
+process.env["SYSTEM_HOSTTYPE"] = 'build';
+process.env["SYSTEM_COLLECTIONURI"] = 'https://dev.azure.com/fake-org/';
+// System.AccessToken is NOT set
+
+task.setInput('configFilePath', path.join(__dirname, 'testFiles', 'config.toml'));
+task.setInput('cliVersion', '3.17.0');
+task.setInput('useWorkloadIdentity', 'true');
+task.setInput('connectedServiceName', 'my-service-connection');
+
+task.run(true);

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessSample.ts
@@ -1,0 +1,32 @@
+// Copyright 2024 Snowflake Inc. 
+// SPDX-License-Identifier: Apache-2.0
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path from 'path';
+import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
+
+const taskPath = path.join(__dirname, '..', '..', 'main.js');
+
+const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
+process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
+process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+
+task.setInput('configFilePath', path.join(__dirname, 'testFiles', 'config.toml'));
+task.setInput('cliVersion', '3.17.0');
+task.setInput('useWorkloadIdentity', 'true');
+
+task.run(true);

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessSample.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 Snowflake Inc. 
+// Copyright 2026 Snowflake Inc.
 // SPDX-License-Identifier: Apache-2.0
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessWithTokenSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessWithTokenSample.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 Snowflake Inc.
+// SPDX-License-Identifier: Apache-2.0
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path from 'path';
+import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
+
+const taskPath = path.join(__dirname, '..', '..', 'main.js');
+
+const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
+process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
+process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+
+// Set required pipeline system variables for workload identity
+process.env["SYSTEM_JOBID"] = 'fake-job-id';
+process.env["SYSTEM_PLANID"] = 'fake-plan-id';
+process.env["SYSTEM_TEAMPROJECTID"] = 'fake-project-id';
+process.env["SYSTEM_HOSTTYPE"] = 'build';
+process.env["SYSTEM_COLLECTIONURI"] = 'https://dev.azure.com/fake-org/';
+process.env["SYSTEM_ACCESSTOKEN"] = 'fake-access-token';
+
+task.setInput('configFilePath', path.join(__dirname, 'testFiles', 'config.toml'));
+task.setInput('cliVersion', '3.17.0');
+task.setInput('useWorkloadIdentity', 'true');
+task.setInput('connectedServiceName', 'my-service-connection');
+
+// Mock azure-devops-node-api to return a fake OIDC token
+task.registerMock('azure-devops-node-api', {
+    getPersonalAccessTokenHandler: () => ({}),
+    WebApi: class {
+        constructor() {}
+        async getTaskApi() {
+            return {
+                async createOidcToken() {
+                    return { oidcToken: 'fake-oidc-token-for-testing' };
+                }
+            };
+        }
+    }
+});
+
+task.run(true);

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -14,7 +14,7 @@
         "Azure Pipelines"
     ],
     "icons": {
-        "default": "images/extension-icon.png"        
+        "default": "images/extension-icon.png"
     },
     "content": {
         "details": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "build-release-task",
     "name": "DevOps for Snowflake CLI",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "publisher": "snowflake",
     "targets": [
         {


### PR DESCRIPTION
  What it does

  Adds workload identity federation (WIF) support to the ConfigureSnowflakeCLI@0 ADO task, allowing Snowflake CLI to authenticate from CI/CD pipelines without stored credentials.

  Key changes

  • task.json — Adds useWorkloadIdentity (boolean) and connectedServiceName (AzureRM service connection) inputs. Version bump to 0.0.8.
  • setupWorkloadIdentity.ts (new) — Requests an OIDC token from ADO via azure-devops-node-api's createOidcToken(), and sets SNOWFLAKE_AUTHENTICATOR, SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER, and SNOWFLAKE_TOKEN env vars.
  • main.ts — Imports and calls setupWorkloadIdentity() when useWorkloadIdentity is true, validates connectedServiceName is provided (fails fast before installing CLI or setting up config).
  • package.json / package-lock.json — Adds azure-devops-node-api dependency.
  • README.md — Adds setup instructions for WIF (Entra ID consent, managed identity, Snowflake user creation, pipeline YAML example).
  • vss-extension.json — Version bump to 0.0.8.
  • azure-pipelines.yml — Minor formatting fixes.
  • Tests — Adds workloadIdentitySuccessSample.ts mock and test cases in _suite.ts verifying both the failure path (missing connectedServiceName) and the success path (env vars are set).