### PR TITLE
Add telemetry markers for Snowflake CLI tracking

### DIFF
--- a/tasks/configure_snowflake_cli/main.ts
+++ b/tasks/configure_snowflake_cli/main.ts
@@ -23,6 +23,11 @@ import { setupWorkloadIdentity } from './src/setupWorkloadIdentity';
 async function run() {
     try {
         task.setResourcePath(path.join(__dirname, 'task.json'));
+
+        // Set telemetry environment variables for Snowflake CLI tracking
+        tl.setVariable('SF_ADO_EXTENSION', 'true');
+        tl.setVariable('SF_CICD_INTEGRATION_VERSION', 'v0.0.8');
+
         const configFilePath: string | undefined = tl.getInput('configFilePath', false);
         const cliVersion: string | undefined = tl.getInput('cliVersion', false);
         const useWorkloadIdentity: boolean = tl.getBoolInput('useWorkloadIdentity', false);


### PR DESCRIPTION
## Summary

Set `SF_ADO_EXTENSION` and `SF_CICD_INTEGRATION_VERSION` env vars so the Snowflake CLI can distinguish the official ADO extension from bare Azure DevOps usage and track the extension version. This enables adoption dashboards for the Nucleus project.

## Changes

- Added `tl.setVariable('SF_ADO_EXTENSION', 'true')` in `main.ts` `run()` function
- Added `tl.setVariable('SF_CICD_INTEGRATION_VERSION', 'v0.0.8')` for version tracking
- Version should be bumped alongside `vss-extension.json` and `task.json` on each release

## Related

- snowflakedb/snowflake-cli#2883 - CLI-side changes to read and report the new fields
- snowflakedb/snowflake-cli-action - companion PR adding same tracking for GitHub Action
- snowflakedbutils/snowflake-cicd-component - companion MR adding same tracking for GitLab