### PR TITLE
Extract integration version to top-level constant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ npm run test
 
 Follow these steps to create a release:
 
-1. **Update Version Numbers**: Modify the `vss-extension.json` and `tasks/configure_snowflake_cli/task.json` files to reflect the new version number.
+1. **Update Version Numbers**: Modify the `vss-extension.json`, `tasks/configure_snowflake_cli/task.json`, and the `INTEGRATION_VERSION` constant in `tasks/configure_snowflake_cli/main.ts` to reflect the new version number.
 
 2. **Set Up the Release Environment**: Navigate to the `tasks/configure_snowflake_cli` directory and execute the following command to create the extension:
 

--- a/tasks/configure_snowflake_cli/main.ts
+++ b/tasks/configure_snowflake_cli/main.ts
@@ -20,13 +20,16 @@ import { setupConfigFile } from './src/setupConfigFile';
 import { installSnowflakeCli } from './src/installSnowflakeCli';
 import { setupWorkloadIdentity } from './src/setupWorkloadIdentity';
 
+// Bump on each release to match vss-extension.json and task.json
+const INTEGRATION_VERSION = 'v0.0.8';
+
 async function run() {
     try {
         task.setResourcePath(path.join(__dirname, 'task.json'));
 
         // Set telemetry environment variables for Snowflake CLI tracking
         tl.setVariable('SF_ADO_EXTENSION', 'true');
-        tl.setVariable('SF_CICD_INTEGRATION_VERSION', 'v0.0.8');
+        tl.setVariable('SF_CICD_INTEGRATION_VERSION', INTEGRATION_VERSION);
 
         const configFilePath: string | undefined = tl.getInput('configFilePath', false);
         const cliVersion: string | undefined = tl.getInput('cliVersion', false);


### PR DESCRIPTION
## Summary

- Extracts `SF_CICD_INTEGRATION_VERSION` value to a top-level `INTEGRATION_VERSION` constant in `main.ts` so it's harder to miss during releases
- Adds `INTEGRATION_VERSION` to the release checklist in `CONTRIBUTING.md`

## Related

- Follow-up to #11 (review feedback from @sfc-gh-jwilkowski)