### PR TITLE
Add tag validation workflow for main-branch reachability

### DIFF
--- a/.github/workflows/validate-tag.yml
+++ b/.github/workflows/validate-tag.yml
@@ -1,0 +1,22 @@
+name: Validate tag
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag is reachable from main
+        run: |
+          TAG_COMMIT=$(git rev-parse "$GITHUB_REF^{commit}")
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error::Tag points to commit $TAG_COMMIT which is not reachable from the main branch. Tags must only reference commits on main."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a new `validate-tag.yml` GitHub Actions workflow that triggers on version tag pushes matching `v[0-9]*`
- Validates that the tagged commit is reachable from the `main` branch, preventing releases from off-main commits

## Test plan
- [ ] Push a tag pointing to a main-branch commit — workflow should pass
- [ ] Push a tag pointing to an off-main commit — workflow should fail with a clear error

SNOW-3345166