### PR TITLE
SNOW-3060165 Install Snowflake CLI with pinned uv instead of pipx

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
       run: |
         cd tasks/configure_snowflake_cli
         export TASK_TEST_TRACE=1
-        unset PIPX_BIN_DIR
+        unset UV_TOOL_BIN_DIR
         npm install -include=dev
         npm test
 

--- a/tasks/configure_snowflake_cli/src/installSnowflakeCli.ts
+++ b/tasks/configure_snowflake_cli/src/installSnowflakeCli.ts
@@ -1,76 +1,120 @@
-// Copyright 2024 Snowflake Inc. 
+// Copyright 2024 Snowflake Inc.
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-﻿import fs from 'fs';
+﻿import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import tl = require('azure-pipelines-task-lib');
 import * as utils from './taskutil';
-import path from 'path';
 
-/**
- * This function ensures that each time `snow` command is executed the system will use 
- * the executable installed using the Snowflake CLI task.
- */
-async function addExecutableToPathVariable(){
-    const pipx_bin_path = tl.getVariable(utils.PIPX_BIN_DIR);
-    if(pipx_bin_path === undefined)
-    {
-        throw new Error('Error environment variable PIPX_BIN_DIR not set');
-    }
-
-    const snowExecutableName = utils.getPlatform() == utils.Platform.Windows? "snow.exe" : "snow";
-    const previous_snow_directory_path = path.join(pipx_bin_path, snowExecutableName);
-    const new_snow_directory_path = tl.getVariable(utils.SNOW_EXECUTABLE_OUTPUT_PATH) ?? path.join(pipx_bin_path, 'snow_pipx_path');
-    utils.createDirectory(new_snow_directory_path);
-    const new_snow_executable_path = path.join(new_snow_directory_path, snowExecutableName);
-    fs.copyFileSync(
-        previous_snow_directory_path,
-        new_snow_executable_path
-        );
-    
-    tl.prependPath(new_snow_directory_path);
+function uvDownloadUrl(): string {
+    return `https://github.com/astral-sh/uv/releases/download/${utils.UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz`;
 }
 
-async function installSnowflakeCliWithPipx(cliVersion:string | undefined){
-    let result = undefined;
-    
-    if(cliVersion === undefined || cliVersion == "latest")
-    {
-        result = tl.execSync("pipx", `install ${utils.SNOWFLAKE_PACKAGE_NAME} --force`);
-    }
-    else
-    {
-        result = tl.execSync("pipx", `install ${utils.SNOWFLAKE_PACKAGE_NAME}==${cliVersion} --force`);
+function sha256File(filePath: string): string {
+    const hash = crypto.createHash('sha256');
+    hash.update(fs.readFileSync(filePath));
+    return hash.digest('hex');
+}
+
+// Downloads the pinned uv release tarball, verifies it against the pinned
+// SHA-256, extracts it, and returns the absolute path to the `uv` binary.
+function installUv(): string {
+    if (utils.getPlatform() !== utils.Platform.Linux) {
+        throw new Error(
+            `The Snowflake CLI Azure DevOps extension currently supports Linux agents only. ` +
+            `Detected platform: ${utils.Platform[utils.getPlatform()]}.`
+        );
     }
 
-    if(result !== undefined && result.code != 0){
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snowflake-cli-uv-'));
+    const archivePath = path.join(workDir, 'uv.tar.gz');
+    const url = uvDownloadUrl();
+
+    const downloadResult = tl.execSync('curl', [
+        '--fail', '--silent', '--show-error', '--location',
+        '--output', archivePath,
+        url,
+    ]);
+    if (downloadResult.code !== 0) {
+        throw new Error(`Failed to download uv ${utils.UV_VERSION} from ${url}: ${downloadResult.stderr}`);
+    }
+
+    const actualSha = sha256File(archivePath);
+    if (actualSha.toLowerCase() !== utils.UV_LINUX_X86_64_SHA256.toLowerCase()) {
+        throw new Error(
+            `uv tarball checksum mismatch. Expected SHA-256 ${utils.UV_LINUX_X86_64_SHA256}, ` +
+            `got ${actualSha}. Refusing to install an unverified binary.`
+        );
+    }
+
+    const extractResult = tl.execSync('tar', ['-xzf', archivePath, '-C', workDir]);
+    if (extractResult.code !== 0) {
+        throw new Error(`Failed to extract uv tarball: ${extractResult.stderr}`);
+    }
+
+    const uvBinary = path.join(workDir, 'uv-x86_64-unknown-linux-gnu', 'uv');
+    if (!fs.existsSync(uvBinary)) {
+        throw new Error(`Extracted uv binary not found at expected path: ${uvBinary}`);
+    }
+    fs.chmodSync(uvBinary, 0o755);
+    return uvBinary;
+}
+
+// Copies the snow executable installed by `uv tool install` into a stable,
+// exported directory so the rest of the pipeline can resolve `snow` on PATH.
+function addExecutableToPathVariable() {
+    const uvToolBinDir = tl.getVariable(utils.UV_TOOL_BIN_DIR);
+    if (uvToolBinDir === undefined) {
+        throw new Error(`Error environment variable ${utils.UV_TOOL_BIN_DIR} not set`);
+    }
+
+    const snowExecutableName = utils.getPlatform() == utils.Platform.Windows ? "snow.exe" : "snow";
+    const installedSnowPath = path.join(uvToolBinDir, snowExecutableName);
+    const outputDir = tl.getVariable(utils.SNOW_EXECUTABLE_OUTPUT_PATH)
+        ?? path.join(uvToolBinDir, 'snow_uv_path');
+    utils.createDirectory(outputDir);
+    const newSnowPath = path.join(outputDir, snowExecutableName);
+    fs.copyFileSync(installedSnowPath, newSnowPath);
+
+    tl.prependPath(outputDir);
+}
+
+function installSnowflakeCliWithUv(cliVersion: string | undefined) {
+    const uvBinary = installUv();
+    const spec = (cliVersion === undefined || cliVersion === "" || cliVersion === "latest")
+        ? utils.SNOWFLAKE_PACKAGE_NAME
+        : `${utils.SNOWFLAKE_PACKAGE_NAME}==${cliVersion}`;
+
+    const result = tl.execSync(uvBinary, ['tool', 'install', '--force', spec]);
+    if (result.code !== 0) {
         throw new Error("Error while installing snowflake-cli: " + result.stderr);
     }
 }
 
-export async function installSnowflakeCli(cliVersion:string | undefined){
+export async function installSnowflakeCli(cliVersion: string | undefined) {
     try {
-        const disableSnowInstallation = tl.getVariable(utils.DISABLE_SNOW_INSTALLATION_WITH_PIPX);
-        if (disableSnowInstallation === undefined || disableSnowInstallation == 'false')
-        {
-            installSnowflakeCliWithPipx(cliVersion);
+        const disableSnowInstallation = tl.getVariable(utils.DISABLE_SNOW_INSTALLATION_WITH_UV);
+        if (disableSnowInstallation === undefined || disableSnowInstallation == 'false') {
+            installSnowflakeCliWithUv(cliVersion);
         }
 
         addExecutableToPathVariable();
-    
     }
-    catch (err:any) {
+    catch (err: any) {
         tl.setResult(tl.TaskResult.Failed, err.message);
     }
 }

--- a/tasks/configure_snowflake_cli/src/taskutil.ts
+++ b/tasks/configure_snowflake_cli/src/taskutil.ts
@@ -16,12 +16,19 @@
 ﻿import * as task from 'azure-pipelines-task-lib';
 import fs from 'fs';
 
-// Enviroment variables names
-export const PIPX_BIN_DIR = "PIPX_BIN_DIR";
+// Environment variable names
+export const UV_TOOL_BIN_DIR = "UV_TOOL_BIN_DIR";
 export const CONFIG_TOML_FILE_OUTPUT_PATH = "CONFIG_TOML_FILE_OUTPUT_PATH";
 export const SNOW_EXECUTABLE_OUTPUT_PATH = "SNOW_EXECUTABLE_OUTPUT_PATH";
-export const DISABLE_SNOW_INSTALLATION_WITH_PIPX = "DISABLE_SNOW_INSTALLATION_WITH_PIPX";
+export const DISABLE_SNOW_INSTALLATION_WITH_UV = "DISABLE_SNOW_INSTALLATION_WITH_UV";
 export const SNOWFLAKE_PACKAGE_NAME = "snowflake-cli";
+
+// Pinned uv version. Bump both values together; the SHA-256 must match the
+// published digest at
+// https://github.com/astral-sh/uv/releases/download/<version>/uv-x86_64-unknown-linux-gnu.tar.gz.sha256
+export const UV_VERSION = "0.11.8";
+export const UV_LINUX_X86_64_SHA256 =
+    "56dd1b66701ecb62fe896abb919444e4b83c5e8645cca953e6ddd496ff8a0feb";
 
 export enum Platform {
     Windows,

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/UvToolBinDirNotSetSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/UvToolBinDirNotSetSample.ts
@@ -23,8 +23,10 @@ const taskPath = path.join(__dirname, '..', '..', 'main.js');
 const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
 process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
-process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+// Deliberately omit UV_TOOL_BIN_DIR to trigger the failure case.
+// Disable the real install so the test does not hit the network.
+process.env["DISABLE_SNOW_INSTALLATION_WITH_UV"] = 'true';
 
 task.setInput('configFilePath', path.join(__dirname, 'testFiles', 'config.toml'));
-task.setInput('cliVersion', '2.1.0');
+task.setInput('cliVersion', '3.17.0');
 task.run(true);

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
@@ -152,21 +152,21 @@ describe('Snowflake Cli configuration', function () {
         });
     });
 
-    it('it should fail if PIPX_BIN_DIR is not set', function(done: Mocha.Done) {
-        this.timeout(10000);    
-        const tp: string = path.join(__dirname, 'PipxBinDirNotSetSample.js');
+    it('it should fail if UV_TOOL_BIN_DIR is not set', function(done: Mocha.Done) {
+        this.timeout(10000);
+        const tp: string = path.join(__dirname, 'UvToolBinDirNotSetSample.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-    
+
         tr.runAsync().then(async () => {
             const test = require ('node:test');
             assert.equal(tr.succeeded, false, 'should have not succeeded');
             assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-            assert.equal(tr.errorIssues.length, 2, "should one error");
-            assert.match(tr.errorIssues[0], new RegExp('Error environment variable PIPX_BIN_DIR'), 'PIPX_BIN_DIR is defined');
+            assert.equal(tr.errorIssues.length, 1, "should have one error");
+            assert.match(tr.errorIssues[0], new RegExp('Error environment variable UV_TOOL_BIN_DIR'), 'UV_TOOL_BIN_DIR is defined');
 
             done();
         }).catch((error) => {
             done(error);
         });
-    });    
+    });
 });

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/configFileNotFoundSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/configFileNotFoundSample.ts
@@ -21,10 +21,10 @@ import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
 const taskPath = path.join(__dirname, '..', '..', 'main.js');
 
 const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
-process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["UV_TOOL_BIN_DIR"] = path.join( __dirname, 'testFiles');
 process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
 process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
-process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+process.env["DISABLE_SNOW_INSTALLATION_WITH_UV"] = 'true';
 
 task.setInput('configFilePath', path.join(__dirname, 'testFiles', 'undefinedConfig.toml'));
 task.setInput('cliVersion', '2.1.0');

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/successSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/successSample.ts
@@ -21,10 +21,10 @@ import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
 const taskPath = path.join(__dirname, '..', '..', 'main.js');
 
 const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
-process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["UV_TOOL_BIN_DIR"] = path.join( __dirname, 'testFiles');
 process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
 process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
-process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+process.env["DISABLE_SNOW_INSTALLATION_WITH_UV"] = 'true';
 
 task.setInput('configFilePath', path.join(__dirname, 'testFiles', 'config.toml'));
 task.setInput('cliVersion', '2.1.0');

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentityMissingVariableSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentityMissingVariableSample.ts
@@ -20,10 +20,10 @@ import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
 const taskPath = path.join(__dirname, '..', '..', 'main.js');
 
 const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
-process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["UV_TOOL_BIN_DIR"] = path.join( __dirname, 'testFiles');
 process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
 process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
-process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+process.env["DISABLE_SNOW_INSTALLATION_WITH_UV"] = 'true';
 
 // Set some pipeline variables but deliberately omit System.AccessToken
 process.env["SYSTEM_JOBID"] = 'fake-job-id';

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessSample.ts
@@ -20,10 +20,10 @@ import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
 const taskPath = path.join(__dirname, '..', '..', 'main.js');
 
 const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
-process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["UV_TOOL_BIN_DIR"] = path.join( __dirname, 'testFiles');
 process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
 process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
-process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+process.env["DISABLE_SNOW_INSTALLATION_WITH_UV"] = 'true';
 
 task.setInput('configFilePath', path.join(__dirname, 'testFiles', 'config.toml'));
 task.setInput('cliVersion', '3.17.0');

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessWithTokenSample.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/workloadIdentitySuccessWithTokenSample.ts
@@ -20,10 +20,10 @@ import {TEMP_CONFIG_FILE_PATH, TEMP_EXEC_OUTPUT_PATH} from './constants'
 const taskPath = path.join(__dirname, '..', '..', 'main.js');
 
 const task: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
-process.env["PIPX_BIN_DIR"] = path.join( __dirname, 'testFiles');
+process.env["UV_TOOL_BIN_DIR"] = path.join( __dirname, 'testFiles');
 process.env["CONFIG_TOML_FILE_OUTPUT_PATH"] = TEMP_CONFIG_FILE_PATH;
 process.env["SNOW_EXECUTABLE_OUTPUT_PATH"] = TEMP_EXEC_OUTPUT_PATH;
-process.env["DISABLE_SNOW_INSTALLATION_WITH_PIPX"] = 'true';
+process.env["DISABLE_SNOW_INSTALLATION_WITH_UV"] = 'true';
 
 // Set required pipeline system variables for workload identity
 process.env["SYSTEM_JOBID"] = 'fake-job-id';


### PR DESCRIPTION
## Summary

- Replaces the `pipx install snowflake-cli` install path with a **pinned uv 0.11.8** Linux x86_64 tarball that is downloaded from GitHub, verified against a pinned SHA-256, and used to run `uv tool install snowflake-cli==<version>`. This mirrors the approach used by [snowflake-cli-action](https://github.com/snowflakedb/snowflake-cli-action) and removes the implicit dependency on whatever Python/pipx the agent happens to have.
- Bumps the env var surface to reflect the new installer (`PIPX_BIN_DIR` → `UV_TOOL_BIN_DIR`, `DISABLE_SNOW_INSTALLATION_WITH_PIPX` → `DISABLE_SNOW_INSTALLATION_WITH_UV`) and updates the test harness + CI workflow to match.
- Refuses to install if the downloaded tarball's SHA-256 does not match the pinned value, or if the agent is not Linux.

## Pinning

| Field | Value |
|---|---|
| `UV_VERSION` | `0.11.8` |
| Tarball | `uv-x86_64-unknown-linux-gnu.tar.gz` from `github.com/astral-sh/uv/releases/download/0.11.8/` |
| `UV_LINUX_X86_64_SHA256` | `56dd1b66701ecb62fe896abb919444e4b83c5e8645cca953e6ddd496ff8a0feb` |

Both values live in `tasks/configure_snowflake_cli/src/taskutil.ts` and **must be bumped together** on any future uv upgrade — `installUv()` refuses the binary if the digest does not match.

## Test plan

- [x] CI: `run-tests.yml` unsets `UV_TOOL_BIN_DIR` before the suite, so the "missing env var" test exercises the failure path
- [x] Unit tests updated: `PipxBinDirNotSetSample.ts` renamed to `UvToolBinDirNotSetSample.ts`, and every sample file now sets `UV_TOOL_BIN_DIR` / `DISABLE_SNOW_INSTALLATION_WITH_UV` instead of the pipx equivalents
- [ ] Smoke: run the extension against a real Azure DevOps agent after merge and confirm `snow --version` resolves on PATH