### PR TITLE
chore: update repository URLs to snowflakedb org

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -23,7 +23,7 @@
     },
     "repository": {
         "type": "git",
-        "uri": "https://github.com/Snowflake-Labs/snowflake-ado-extension"
+        "uri": "https://github.com/snowflakedb/snowflake-ado-extension"
     },
     "galleryFlags": [
         "Public",
@@ -34,13 +34,13 @@
             "uri": "https://docs.snowflake.com/en/developer-guide/snowflake-cli-v2/index"
         },
         "Repository": {
-            "uri": "https://github.com/Snowflake-Labs/snowflake-ado-extension"
+            "uri": "https://github.com/snowflakedb/snowflake-ado-extension"
         },
         "Issues": {
-            "uri": "https://github.com/Snowflake-Labs/snowflake-ado-extension/issues"
+            "uri": "https://github.com/snowflakedb/snowflake-ado-extension/issues"
         },
         "License": {
-            "uri": "https://github.com/Snowflake-Labs/snowflake-ado-extension/blob/main/LICENSE"
+            "uri": "https://github.com/snowflakedb/snowflake-ado-extension/blob/main/LICENSE"
         }
     },
 


### PR DESCRIPTION
## Summary
- The `vss-extension.json` manifest still referenced the old `Snowflake-Labs` GitHub organization in the `repository.uri` and `links` (Repository, Issues, License) sections.
- The project has moved to `snowflakedb`, so the URLs shown in the Azure DevOps Marketplace listing should reflect the current home of the code.
- Cleanup prepares the manifest for the upcoming v1.0.0 PuPr release.

## Test plan
- [x] `grep -n Snowflake-Labs vss-extension.json` returns no matches
- [ ] Manifest continues to parse as valid JSON in the packaging step (`npx run create:extension`)