### PR TITLE
chore: bump extension version to 1.0.0 for Public Preview

### DIFF
--- a/tasks/configure_snowflake_cli/main.ts
+++ b/tasks/configure_snowflake_cli/main.ts
@@ -21,7 +21,7 @@ import { installSnowflakeCli } from './src/installSnowflakeCli';
 import { setupWorkloadIdentity } from './src/setupWorkloadIdentity';
 
 // Bump on each release to match vss-extension.json and task.json
-const INTEGRATION_VERSION = 'v0.0.8';
+const INTEGRATION_VERSION = 'v1.0.0';
 
 async function run() {
     try {

--- a/tasks/configure_snowflake_cli/task.json
+++ b/tasks/configure_snowflake_cli/task.json
@@ -8,9 +8,9 @@
     "category": "Utility",
     "author": "Snowflake Labs",
     "version": {
-        "Major": 0,
+        "Major": 1,
         "Minor": 0,
-        "Patch": 8
+        "Patch": 0
     },
     "instanceNameFormat": "Configure Snowflake CLI",
     "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "build-release-task",
     "name": "DevOps for Snowflake CLI",
-    "version": "0.0.8",
+    "version": "1.0.0",
     "publisher": "snowflake",
     "targets": [
         {


### PR DESCRIPTION
## Summary
- Bumps `vss-extension.json`, `tasks/configure_snowflake_cli/task.json`, and the `INTEGRATION_VERSION` constant in `tasks/configure_snowflake_cli/main.ts` from `0.0.8` to `1.0.0`.
- Prepares the repository for the Public Preview (PuPr) release, which will be tagged `v1.0.0` with the floating `v1` / `v1.0` aliases once this merges.
- `v0.0.8` was never tagged or released; the jump to `1.0.0` marks the PuPr milestone rather than a semantic break.

## Test plan
- [x] `grep "0.0.8\|v0.0.8"` returns no matches outside `CHANGELOG`/`package-lock`
- [x] All three files stay in sync as required by `CONTRIBUTING.md`
- [ ] Packaging step (`npx run create:extension`) produces a vsix named `Snowflake.build-release-task-1.0.0.vsix`