### PR TITLE
Add scheduled latest-CLI compatibility checks (SNOW-3428283)

### DIFF
--- a/.github/workflows/compat-latest-cli.yml
+++ b/.github/workflows/compat-latest-cli.yml
@@ -1,0 +1,60 @@
+name: Compatibility — latest Snowflake CLI
+
+# Daily scheduled smoke-test that installs the latest published Snowflake
+# CLI release via the same `uv tool install snowflake-cli` path used by
+# the extension's ConfigureSnowflakeCLI task (see
+# tasks/configure_snowflake_cli/src/installSnowflakeCli.ts).
+#
+# The authoritative end-to-end is the daily run of azure-pipelines.yml in
+# Azure DevOps, which exercises the published task from the Visual Studio
+# Marketplace. This GitHub Actions workflow is a fast-feedback mirror: if
+# a new CLI release breaks installation, failure shows up on the GitHub
+# dashboard the squad already watches, alongside `run-tests.yml`.
+#
+# Addresses SNOW-3428283 (Native CI/CD Integrations ORR §2.2 / §7.4 —
+# 48-hour latest-CLI compatibility SLO). Failure on `main` is the
+# L2-Critical alert trigger defined in ORR §4.3.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install-latest:
+    name: Install latest CLI via task install path
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Mirror the task's pinned uv install (installSnowflakeCli.ts). If
+      # taskutil.ts is bumped to a new uv version without a corresponding
+      # update here, the workflow must be updated in the same PR.
+      - name: Install pinned uv
+        run: |
+          set -euo pipefail
+          UV_VERSION="0.11.8"
+          UV_SHA256="56dd1b66701ecb62fe896abb919444e4b83c5e8645cca953e6ddd496ff8a0feb"
+          UV_ARCHIVE="uv-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL -o "/tmp/${UV_ARCHIVE}" \
+            "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}"
+          echo "${UV_SHA256}  /tmp/${UV_ARCHIVE}" | sha256sum -c -
+          tar -xzf "/tmp/${UV_ARCHIVE}" -C /tmp
+          sudo install -m 0755 "/tmp/uv-x86_64-unknown-linux-gnu/uv" /usr/local/bin/uv
+          uv --version
+
+      - name: Install latest Snowflake CLI
+        run: uv tool install snowflake-cli
+
+      - name: Smoke-test installed CLI
+        run: |
+          set -e
+          export PATH="$HOME/.local/bin:$PATH"
+          snow --version
+          snow --help > /dev/null
+          snow connection list > /dev/null

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,3 +36,17 @@ steps:
 
 - script: snow connection list
   displayName: 'Snow Connection List'
+
+# Compat check against the latest published Snowflake CLI release. Paired
+# with the pinned-version step above so regressions in either the CLI or
+# the task are caught. Addresses SNOW-3428283 (Native CI/CD Integrations
+# ORR §2.2 / §7.4 — 48-hour latest-CLI compatibility SLO). Runs on the
+# same daily midnight schedule already defined above.
+- task: ConfigureSnowflakeCLI@0
+  inputs:
+    configFilePath: './config.toml'
+    cliVersion: 'latest'
+  displayName: 'SnowflakeCliTest (latest CLI)'
+
+- script: snow --version && snow --help > /dev/null && snow connection list
+  displayName: 'Smoke-test latest CLI'


### PR DESCRIPTION
## Summary
Adds daily compatibility checks against the **latest** Snowflake CLI release across two complementary surfaces:

1. **`azure-pipelines.yml`** — new `ConfigureSnowflakeCLI@0` step with `cliVersion: 'latest'` alongside the existing pinned `3.15.0` step, plus a smoke test. This is the authoritative end-to-end: it runs the task as published to the Visual Studio Marketplace, so it catches breakage in either the CLI release or the task itself. Runs on the daily midnight schedule already configured in the pipeline. The pinned-version step stays so CLI regressions and task regressions remain distinguishable.
2. **`.github/workflows/compat-latest-cli.yml`** — a fast-feedback mirror that reproduces the task's pinned-`uv` install path from `tasks/configure_snowflake_cli/src/installSnowflakeCli.ts` and installs `snowflake-cli` directly, so failures show up on the GitHub dashboard the squad already watches (alongside `run-tests.yml`).

## Why both surfaces
- The ADO pipeline is the only place the **published** task actually runs; if the task is broken but the install path is fine, only this surface catches it.
- The GH Actions workflow runs a minute after its `schedule:` trigger; the ADO pipeline has a scheduling lag of up to 75 minutes. Fast signal on GH + authoritative E2E on ADO.

## Why a schedule, not a release webhook on snowflake-cli?
- No cross-repo token / webhook to maintain in `snowflakedb/snowflake-cli`.
- Daily cadence comfortably meets the 48 h SLO from [ORR §2.2](https://docs.google.com/document/d/1tIt17OqIhogc8KjijGL815kRI-F4x6Mw45NvnU8mloM).
- Symmetric with the GitHub Action and GitLab component siblings.

## Addresses
- Pre-GA gap in the Native CI/CD Integrations ORR §2.2 / §7.4 — 48 h latest-CLI compat SLO.
- Failure on `main` (either surface) is the L2-Critical trigger already defined in ORR §4.3.

## Coupling warning (for future reviewers)
The hard-coded `UV_VERSION` / `SHA256` in `compat-latest-cli.yml` must stay in sync with `tasks/configure_snowflake_cli/src/taskutil.ts`. If `taskutil.ts` bumps `uv`, the workflow must be updated in the same PR — comment in the workflow file reminds you.

## Jira
- SNOW-3428283

## Test plan
- [ ] After merge, manually `workflow_dispatch` `compat-latest-cli.yml` and confirm it's green.
- [ ] Observe the next daily ADO pipeline run and confirm both the pinned `3.15.0` step and the new `latest` step are green.
- [ ] Optional: temporarily point `compat-latest-cli.yml` at a deleted CLI version on a throwaway branch to verify it goes red as expected.