### PR TITLE
SNOW-3428370 Add live OIDC E2E test to Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-﻿trigger:
+trigger:
 - main
 
 schedules:
@@ -11,28 +11,87 @@ schedules:
 pool:
   vmImage: ubuntu-latest
 
-steps:
-- script: |
-    cat <<EOF > config.toml
-    default_connection_name = "myconnection"
+# Pipeline-level variables the OIDC E2E stage expects to be provided via the
+# Azure DevOps project variables (or a linked variable group):
+#   - SNOWFLAKE_ACCOUNT:                Snowflake account identifier of the
+#                                       shared CI/CD integrations test account.
+#   - SNOWFLAKE_USER:                   Service user created with
+#                                       TYPE = SERVICE and WORKLOAD_IDENTITY
+#                                       (TYPE = OIDC) whose SUBJECT matches
+#                                       this pipeline's ADO federated identity.
+#   - SNOWFLAKE_ADO_SERVICE_CONNECTION: Name of the ARM service connection
+#                                       configured with workload identity
+#                                       federation against the corresponding
+#                                       Entra ID App Registration.
+# When SNOWFLAKE_ACCOUNT is empty (e.g. a fork or a minimal setup) the OIDC
+# E2E stage is skipped — the smoke stage still runs and guards install/config.
 
-    [connections]
-    [connections.myconnection]
-    user = "demo_user"
-    warehouse = "COMPUTE_WH"
-    database = "mytestdb"
-    schema = "PUBLIC"
-    role = "ACCOUNTADMIN"
-    region = "us-east-1"
-    EOF
-  displayName: 'Create Sample config.toml'
+stages:
+  - stage: Smoke
+    displayName: 'Install + config smoke test'
+    jobs:
+      - job: smoke
+        displayName: 'Install CLI and deploy config.toml'
+        steps:
+          - script: |
+              cat <<EOF > config.toml
+              default_connection_name = "myconnection"
 
-- task: ConfigureSnowflakeCLI@0
-  inputs:
-    configFilePath: './config.toml'
-    cliVersion: '3.15.0'
+              [connections]
+              [connections.myconnection]
+              user = "demo_user"
+              warehouse = "COMPUTE_WH"
+              database = "mytestdb"
+              schema = "PUBLIC"
+              role = "ACCOUNTADMIN"
+              region = "us-east-1"
+              EOF
+            displayName: 'Create Sample config.toml'
 
-  displayName: SnowflakeCliTest
+          - task: ConfigureSnowflakeCLI@0
+            inputs:
+              configFilePath: './config.toml'
+              cliVersion: '3.15.0'
+            displayName: 'ConfigureSnowflakeCLI@0 (pinned CLI)'
 
-- script: snow connection list
-  displayName: 'Snow Connection List'
+          - script: snow connection list
+            displayName: 'snow connection list'
+
+  - stage: OidcE2E
+    displayName: 'OIDC workload identity E2E (live Snowflake handshake)'
+    dependsOn: Smoke
+    condition: and(succeeded(), ne(variables['SNOWFLAKE_ACCOUNT'], ''))
+    jobs:
+      - job: oidc_e2e_latest
+        displayName: 'Latest CLI — OIDC handshake against Snowflake'
+        steps:
+          - task: ConfigureSnowflakeCLI@0
+            inputs:
+              useWorkloadIdentity: true
+              connectedServiceName: $(SNOWFLAKE_ADO_SERVICE_CONNECTION)
+            displayName: 'ConfigureSnowflakeCLI@0 (OIDC, latest CLI)'
+
+          - script: |
+              set -euo pipefail
+              echo "Snowflake CLI version:"
+              snow --version
+              echo
+              echo "Verifying that the task exported the expected WIF env vars..."
+              : "${SNOWFLAKE_AUTHENTICATOR:?SNOWFLAKE_AUTHENTICATOR not set by the task}"
+              : "${SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER:?provider not set by the task}"
+              : "${SNOWFLAKE_TOKEN:?token not set by the task}"
+              test "$SNOWFLAKE_AUTHENTICATOR" = "WORKLOAD_IDENTITY"
+              test "$SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER" = "OIDC"
+              echo "WIF env vars look correct (token value masked)."
+            displayName: 'Verify WIF env vars (no secret values logged)'
+
+          - script: |
+              set -euo pipefail
+              # Temporary connection (-x) authenticates using the SNOWFLAKE_*
+              # env vars the task just set, exercising the full OIDC path:
+              # ADO OIDC token -> Snowflake WIF -> Snowflake session.
+              snow connection test -x
+            displayName: 'snow connection test -x (OIDC handshake)'
+            env:
+              SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)
+              SNOWFLAKE_USER: $(SNOWFLAKE_USER)


### PR DESCRIPTION
## Summary

Addresses the [ORR](https://docs.google.com/document/d/1x7ekVQWngnVGN4gpgSFdbFoMpQhJ3v519fXP0JEAh1A) gap called out under [SNOW-3428370](https://snowflakecomputing.atlassian.net/browse/SNOW-3428370): OIDC workload identity had unit-test coverage only, and correctness against a real Snowflake account relied on manual verification. This PR wires an automatic end-to-end OIDC handshake into the release pipeline so every release confirms that ADO OIDC auth still works.

- Split `azure-pipelines.yml` into two stages:
  - `Smoke` — preserves the existing install + `config.toml` path on a pinned CLI version.
  - `OidcE2E` — runs `ConfigureSnowflakeCLI@0` with `useWorkloadIdentity: true` and `connectedServiceName: $(SNOWFLAKE_ADO_SERVICE_CONNECTION)`, asserts the task exported the expected `SNOWFLAKE_AUTHENTICATOR` / `SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER` / `SNOWFLAKE_TOKEN` env vars, then runs `snow connection test -x` against the shared CI/CD integrations test account — exercising the full ADO OIDC token → Snowflake WIF → session handshake.
- The OIDC stage is gated on the `SNOWFLAKE_ACCOUNT` pipeline variable being set. Forks or minimal setups get the smoke stage without failing for missing secrets/service connection.

## Prerequisites for the OIDC stage

The ADO project running this pipeline needs (infra already exists for the shared test account; this PR only wires the pipeline):

- `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER` — project variables (or a linked variable group).
- `SNOWFLAKE_ADO_SERVICE_CONNECTION` — name of the ARM service connection configured with workload identity federation against the Entra ID App Registration whose federated credential subject matches this pipeline. That subject is the one set on the Snowflake service user's `WORKLOAD_IDENTITY (TYPE = OIDC, ...)`.

## Test plan

- [ ] On merge to `main`, verify the `Smoke` stage still passes as today.
- [ ] Set the three project variables above on the release pipeline, re-run, and confirm `OidcE2E` succeeds: task logs show `SNOWFLAKE_AUTHENTICATOR=WORKLOAD_IDENTITY`, no token value is logged, and `snow connection test -x` reports a successful connection.
- [ ] Unset `SNOWFLAKE_ACCOUNT` on a throwaway run and confirm `OidcE2E` is skipped by the stage condition (existing smoke still runs).

[SNOW-3428370]: https://snowflakecomputing.atlassian.net/browse/SNOW-3428370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ