### PR TITLE
Set SF_CICD_AUTH_TYPE=oidc for auth-type telemetry

### DIFF
--- a/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
+++ b/tasks/configure_snowflake_cli/src/setupWorkloadIdentity.ts
@@ -65,5 +65,8 @@ export async function setupWorkloadIdentity(connectedServiceName: string) {
     tl.setVariable('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER', 'OIDC');
     tl.setVariable('SNOWFLAKE_TOKEN', oidcToken, true);
 
+    // Telemetry: tell the Snowflake CLI which auth type this task configured.
+    tl.setVariable('SF_CICD_AUTH_TYPE', 'oidc');
+
     console.log('Workload identity authentication configured successfully (OIDC).');
 }

--- a/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
+++ b/tasks/configure_snowflake_cli/tests/configureSnowflakeCliTest/_suite.ts
@@ -102,6 +102,10 @@ describe('Snowflake Cli configuration', function () {
                 assert.equal(tr.stdout.indexOf('SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER=OIDC') >= 0, true, "should set SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER");
             })
 
+            await test('Should set SF_CICD_AUTH_TYPE to oidc', () => {
+                assert.equal(tr.stdout.indexOf('SF_CICD_AUTH_TYPE=oidc') >= 0, true, "should set SF_CICD_AUTH_TYPE");
+            })
+
             await test('Should set SNOWFLAKE_TOKEN as secret', () => {
                 assert.equal(tr.stdout.indexOf('SNOWFLAKE_TOKEN=') >= 0, true, "should set SNOWFLAKE_TOKEN");
             })


### PR DESCRIPTION
## What

When the task configures workload identity (OIDC), it now sets `SF_CICD_AUTH_TYPE=oidc` (via `tl.setVariable`) alongside the existing `SNOWFLAKE_*` variables in `setupWorkloadIdentity.ts`. Adds a matching assertion to the workload-identity success case in the unit-test suite.

## Why

The Snowflake CLI already records which integration ran (`command_ci_environment`) and its version (`command_ci_integration_version`) but not **how** the user authenticated. This adds that signal so we can measure OIDC adoption across CI/CD. It mirrors the existing `SF_CICD_INTEGRATION_VERSION` marker and is read by the CLI's new `command_ci_auth_type` telemetry field (see snowflakedb/snowflake-cli#3128).

The variable is set only on the OIDC path — exactly where the task configures auth. Credential-based fallback is configured by the user in later pipeline steps, which the task never sees, so it intentionally leaves the field unset.

## Notes

- No version bump (`task.json` / `vss-extension.json` / `main.ts` `INTEGRATION_VERSION`) — that's a release-time step.
- Extending later (new auth types, or the deprecated `snowflake-cli-action`) is a one-line `setVariable`/`echo` in the relevant auth branch; the CLI records whatever value is set.